### PR TITLE
feat: adding RGAA 1.1.1,1.1.2,1.1.5, rules for img, area, svg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { RGAA2 } from './rules/RGAA2.js';
 export { RGAA8 } from './rules/RGAA8.js';
 export { RGAA3 } from './rules/RGAA3.js';
+export { RGAA1 } from './rules/RGAA1.js';

--- a/src/rules/RGAA1.ts
+++ b/src/rules/RGAA1.ts
@@ -1,0 +1,49 @@
+import { LogMessageParams } from '../types.js';
+
+export class RGAA1 {
+  // eslint-disable-next-line class-methods-use-this
+  public RGAA11(elements: Array<HTMLElement | SVGElement>) {
+    const wrongElement: Array<LogMessageParams> = [];
+    elements.forEach(el => {
+      if (el instanceof HTMLImageElement) {
+        const { alt, title, ariaLabel } = el;
+        const ariaLabelledby = el.getAttribute('aria-labelledby');
+        if (!alt && !title && !ariaLabel && !ariaLabelledby) {
+          wrongElement.push({
+            element: el.outerHTML,
+            rule: 'RGAA - 1.1.1',
+            ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.1',
+            message: 'img elements should have alt, aria-label, title or aria-labelledby',
+          });
+        }
+      }
+
+      if (el instanceof HTMLAreaElement) {
+        const { alt, ariaLabel } = el;
+        if (!alt && !ariaLabel) {
+          wrongElement.push({
+            element: el.outerHTML,
+            rule: 'RGAA - 1.1.2',
+            ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.2',
+            message: 'Area element should have alt or aria-label',
+          });
+        }
+      }
+
+      if (el instanceof SVGSVGElement) {
+        const { role, ariaLabel } = el;
+        const ariaLabelledby = el.getAttribute('aria-labelledby');
+        if (role === 'img' && !ariaLabel && !ariaLabelledby) {
+          wrongElement.push({
+            element: el.outerHTML,
+            rule: 'RGAA - 1.1.5',
+            ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.5',
+            message: 'SVG element with role img should have aria-label or aria-labelledby',
+          });
+        }
+      }
+    });
+
+    return wrongElement;
+  }
+}

--- a/tests/Rules/RGAA1.test.ts
+++ b/tests/Rules/RGAA1.test.ts
@@ -1,0 +1,100 @@
+import { expect, it } from 'vitest';
+import { RGAA1 } from '../../src/rules/RGAA1';
+
+const ElementsWithoutLabels = [
+  Object.defineProperties(document.createElement('img'), {
+    alt: { value: undefined, writable: true },
+    title: { value: undefined, writable: true },
+    'aria-labelledby': { value: undefined, writable: true },
+    'aria-label': { value: undefined, writable: true },
+  }),
+  Object.defineProperties(document.createElement('area'), {
+    alt: { value: undefined, writable: true },
+    'aria-label': { value: undefined, writable: true },
+  }),
+  Object.defineProperties(document.createElementNS('http://www.w3.org/2000/svg', 'svg'), {
+    role: { value: 'img', writable: true },
+    'aria-labelledby': { value: undefined, writable: true },
+    'aria-label': { value: undefined, writable: true },
+  }),
+];
+
+const ElementsWithLabels = [
+  Object.defineProperties(document.createElement('img'), {
+    id: { value: 1, writable: true },
+    alt: { value: 'alt', writable: true },
+    title: { value: undefined, writable: true },
+    'aria-labelledby': { value: undefined, writable: true },
+    'aria-label': { value: undefined, writable: true },
+  }),
+  Object.defineProperties(document.createElement('img'), {
+    id: { value: 2, writable: true },
+    ariaLabel: {
+      value: 'aria',
+      writable: true,
+    },
+    title: { value: undefined, writable: true },
+    alt: { value: undefined, writable: true },
+    'aria-labelledby': { value: undefined, writable: true },
+  }),
+  Object.defineProperties(document.createElement('img'), {
+    id: { value: 3, writable: true },
+    alt: { value: undefined, writable: true },
+    title: { value: 'title', writable: true },
+    'aria-labelledby': { value: undefined, writable: true },
+    'aria-label': { value: undefined, writable: true },
+  }),
+  (() => {
+    const element = document.createElement('img');
+    element.setAttribute('aria-labelledby', 'labelledby');
+    return element;
+  })(),
+  (() => {
+    const element = document.createElement('area');
+    element.setAttribute('aria-label', 'label');
+    return element;
+  })(),
+  (() => {
+    const element = document.createElement('area');
+    element.setAttribute('alt', 'alt');
+    return element;
+  })(),
+  (() => {
+    const element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    element.setAttribute('role', 'img');
+    element.setAttribute('aria-label', 'label');
+    return element;
+  })(),
+  (() => {
+    const element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    element.setAttribute('role', 'img');
+    element.setAttribute('aria-labelledby', 'labelledby');
+    return element;
+  })(),
+];
+
+const core = new RGAA1();
+
+it('RGAA1.1 - frame & iframe should have an attribute title', () => {
+  expect(core.RGAA11(ElementsWithLabels)).toStrictEqual([]);
+  expect(core.RGAA11(ElementsWithoutLabels)).toStrictEqual([
+    {
+      element: '<img>',
+      message: 'img elements should have alt, aria-label, title or aria-labelledby',
+      rule: 'RGAA - 1.1.1',
+      ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.1',
+    },
+    {
+      element: '<area>',
+      message: 'Area element should have alt or aria-label',
+      rule: 'RGAA - 1.1.2',
+      ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.2',
+    },
+    {
+      element: '<svg></svg>',
+      message: 'SVG element with role img should have aria-label or aria-labelledby',
+      rule: 'RGAA - 1.1.5',
+      ruleLink: 'https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1.5',
+    },
+  ]);
+});


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

Indicate here the number of the GitHub issue associated with this Pull Request.

**Context :**

Adding RGAA 1.1.1 , 1.1.2 , 1.1.5 rules that verify alt,title,aria-label,aria-labelled-by.

**Proposed Changes :**

- RGAA 1.1.1:  
```
Dans le cas où il s’agit d’un élément <img>, vérifier que l’image est pourvue au moins d’une alternative textuelle parmi les suivantes :
Passage de texte associé via l’attribut WAI-ARIA aria-labelledby ;
Contenu de l’attribut WAI-ARIA aria-label ;
Contenu de l’attribut alt ;
Contenu de l’attribut title.
```
- RGAA 1.1.2
```
Vérifier que la zone réactive est pourvue au moins d’une alternative textuelle parmi les suivantes :
Contenu de l’attribut WAI-ARIA aria-label ;
Contenu de l’attribut alt ;
```
-RGAA 1.1.5
```
La balise <svg> possède un attribut WAI-ARIA role="img" ;
Le cas échéant, vérifier que l’élément <svg> est pourvu au moins d’une alternative textuelle parmi les suivantes :
Contenu de l’élément <title> ;
Passage de texte associé via l’attribut WAI-ARIA aria-labelledby ;
Contenu de l’attribut WAI-ARIA aria-label ;
```

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

Add here any other information you deem relevant to this Pull Request.
